### PR TITLE
Add note to 2018-12-03-7 about other smart-pipeline placeholders

### DIFF
--- a/website/blog/2018-12-03-7.2.0.md
+++ b/website/blog/2018-12-03-7.2.0.md
@@ -47,9 +47,9 @@ Private accessors [are also coming](https://github.com/babel/babel/pull/9101), a
 
 ### "Smart" Pipeline Operator Parsing ([#8289](https://github.com/babel/babel/pull/8289))
 
-Thanks to the work of [James DiGioia](https://github.com/mAAdhaTTah) and [J. S. Choi](https://github.com/js-choi), `@babel/parser` now also supports the [Smart Pipeline Operator](https://github.com/js-choi/proposal-smart-pipelines/), in addition to the [Simple](https://github.com/tc39/proposal-pipeline-operator) version.
+Thanks to the work of [James DiGioia](https://github.com/mAAdhaTTah) and [J. S. Choi](https://github.com/js-choi), `@babel/parser` now also can parse the [Smart Pipeline Operator](https://github.com/js-choi/proposal-smart-pipelines/), in addition to the [minimal version](https://github.com/tc39/proposal-pipeline-operator).
 
-We currently only support the "core" of the smart pipeline proposal, and not the additional features.
+We currently only support the "core" of the smart pipeline proposal, and not any additional features. We also currently support only `#` as a preliminary placeholder. The [actual placeholder has not yet been decided](https://github.com/tc39/proposal-pipeline-operator/issues/91), and other possibilities such as `?`, `@`, and `%` may be experimentally supported by `@babel/parser` in the future.
 
 ```javascript=
 // "Smart"


### PR DESCRIPTION
As per https://github.com/babel/website/commit/6ea04ffe934e0e7b1da6c96e4d20f285f0760184#commitcomment-31546504.